### PR TITLE
keep user in localstorage

### DIFF
--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -1,5 +1,10 @@
-import React, { createContext, useCallback } from 'react';
+import React, { createContext, useCallback, useState } from 'react';
 import api from '../services/api';
+
+interface AuthState {
+  token: string;
+  user: object;
+}
 
 interface SignInCredentials {
   email: string;
@@ -7,7 +12,7 @@ interface SignInCredentials {
 }
 
 interface AuthContextData {
-  name: string;
+  user: object;
   signIn(credentials: SignInCredentials): Promise<void>;
 }
 export const AuthContext = createContext<AuthContextData>(
@@ -15,17 +20,33 @@ export const AuthContext = createContext<AuthContextData>(
 );
 
 export const AuthProvider: React.FC = ({ children }) => {
+  const [data, setData] = useState<AuthState>(() => {
+    const token = localStorage.getItem('@GoBarber:token');
+    const user = localStorage.getItem('@GoBarber:user');
+
+    if (token && user) {
+      return { token, user: JSON.parse(user) };
+    }
+
+    return {} as AuthState;
+  });
+
   const signIn = useCallback(async ({ email, password }) => {
     const response = await api.post('/sessions', {
       email,
       password,
     });
 
-    console.log(response.data);
+    const { token, user } = response.data;
+
+    localStorage.setItem('@GoBarber:token', token);
+    localStorage.setItem('@GoBarber:user', JSON.stringify(user));
+
+    setData({ token, user });
   }, []);
 
   return (
-    <AuthContext.Provider value={{ name: 'Juliano', signIn }}>
+    <AuthContext.Provider value={{ user: data.user, signIn }}>
       {children}
     </AuthContext.Provider>
   );

--- a/frontend/src/pages/SignIn/index.tsx
+++ b/frontend/src/pages/SignIn/index.tsx
@@ -23,7 +23,7 @@ interface SignInFormData {
 const SignIn: React.FC = () => {
   const formRef = useRef<FormHandles>(null);
 
-  const { signIn } = useContext(AuthContext);
+  const { signIn, user } = useContext(AuthContext);
   // eslint-disable-next-line @typescript-eslint/ban-types
   const handleSubmit = useCallback(
     async (data: SignInFormData) => {


### PR DESCRIPTION
Nessa etapa, configurei a aplicação para receber os dados do usuário na autenticação e guardá-las no localStorage afim de manter conectado pelo tempo do token que foi gerado pela api.